### PR TITLE
A single persistent TCP connection blocks listener from serving other requests

### DIFF
--- a/syslog/syslog_producer.go
+++ b/syslog/syslog_producer.go
@@ -140,7 +140,7 @@ func (this *SyslogProducer) startTCPServer() {
 				return
 			}
 
-			this.scan(connection)
+			go this.scan(connection)
 		}
 	}()
 	glog.Infof("Listening for messages at TCP %s", this.config.TCPAddr)


### PR DESCRIPTION
Calling `scan()` for TCP listener in a goroutine.

Issue #3